### PR TITLE
Fix config injection logic

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -354,8 +354,10 @@ class Flow:
             sig_obj = inspect.signature(fn)
 
             def wrapper(*args, **kwargs):
-                merged = {**self.config.defaults(fn.__name__), **kwargs}
-                bound = sig_obj.bind_partial(*args, **merged)
+                bound = sig_obj.bind_partial(*args, **kwargs)
+                for name, val in self.config.defaults(fn.__name__).items():
+                    if name not in bound.arguments:
+                        bound.arguments[name] = val
                 bound.apply_defaults()
 
                 node = Node(fn, bound.args, bound.kwargs)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -50,6 +50,18 @@ def test_defaults_override(tmp_path):
     assert flow.run(node) == 8
 
 
+def test_positional_args_ignore_config(tmp_path):
+    conf = Config({"add": {"y": 5}})
+    flow = Flow(config=conf, cache=ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]), log=False)
+
+    @flow.task()
+    def add(x, y):
+        return x + y
+
+    node = add(2, 3)
+    assert flow.run(node) == 5
+
+
 def test_config_from_yaml(tmp_path):
     cfg_path = Path(__file__).with_name("config.yaml")
     with open(cfg_path) as f:

--- a/tutorial.py
+++ b/tutorial.py
@@ -29,7 +29,7 @@ def square(z):
 
 
 if __name__ == "__main__":
-    node = square(add(square(square(2)), square(square(2))))
+    node = square(add(square(square(2)), y=square(square(2))))
 
     result = flow.run(node)
     print(node, result)


### PR DESCRIPTION
## Summary
- ensure config defaults don't override explicit positional args
- test ignoring config when argument provided

## Testing
- `pytest -q`
- `python tutorial.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd66c9be0832bad3b1a17ffd5ffdc