### PR TITLE
Fix DiskJoblib subdir for complex DAG signatures

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -104,7 +104,12 @@ class DiskJoblib(Cache):
         self.lock = lock
 
     def _subdir(self, key: str) -> Path:
-        fn = key.split("(", 1)[0]
+        """Return the directory corresponding to the node's function name."""
+        lines = key.strip().splitlines()
+        call_line = lines[-2] if len(lines) >= 2 else lines[0]
+        if " = " in call_line:
+            call_line = call_line.split(" = ", 1)[1]
+        fn = call_line.split("(", 1)[0]
         sub = self.root / fn
         sub.mkdir(parents=True, exist_ok=True)
         return sub


### PR DESCRIPTION
## Summary
- handle multi-line node signatures when determining the directory for DiskJoblib
- parse function name using simple string operations

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c47e6ca74832bad7dbf9f57dedd61