### PR TITLE
Detect diamond dependencies for script rendering

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -278,20 +278,31 @@ def _build_script(root: Node):
 
 
 def _is_linear_chain(root: Node) -> bool:
+    """Return True if ``root`` forms a simple chain without shared nodes."""
+
     seen: set[Node] = set()
+    indeg: Dict[Node, int] = defaultdict(int)
+    ok = True
 
-    def visit(n: Node) -> bool:
+    def visit(n: Node):
+        nonlocal ok
         if n in seen:
-            return False
+            return
         seen.add(n)
-        child_nodes = [d for d in n.deps if isinstance(d, Node)]
-        if len(child_nodes) == 0:
-            return True
-        if len(child_nodes) > 1:
-            return False
-        return visit(child_nodes[0])
 
-    return visit(root)
+        child_nodes = [d for d in n.deps if isinstance(d, Node)]
+        for c in child_nodes:
+            indeg[c] += 1
+            if indeg[c] > 1:
+                ok = False
+        if len(child_nodes) > 1:
+            ok = False
+            return
+        if child_nodes:
+            visit(child_nodes[0])
+
+    visit(root)
+    return ok
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- detect diamond dependencies in `_is_linear_chain`
- keep tests green

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4d232d0c832ba85074ae876817ea