### PR TITLE
Improve diamond detection

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -278,31 +278,26 @@ def _build_script(root: Node):
 
 
 def _is_linear_chain(root: Node) -> bool:
-    """Return True if ``root`` forms a simple chain without shared nodes."""
+    """Return ``True`` if the graph rooted at ``root`` has no diamond dependencies."""
 
     seen: set[Node] = set()
-    indeg: Dict[Node, int] = defaultdict(int)
-    ok = True
+    indeg: Dict[str, int] = defaultdict(int)
+    diamond = False
 
     def visit(n: Node):
-        nonlocal ok
+        nonlocal diamond
         if n in seen:
             return
         seen.add(n)
 
-        child_nodes = [d for d in n.deps if isinstance(d, Node)]
-        for c in child_nodes:
-            indeg[c] += 1
-            if indeg[c] > 1:
-                ok = False
-        if len(child_nodes) > 1:
-            ok = False
-            return
-        if child_nodes:
-            visit(child_nodes[0])
+        for c in (d for d in n.deps if isinstance(d, Node)):
+            indeg[c.signature] += 1
+            if indeg[c.signature] > 1:
+                diamond = True
+            visit(c)
 
     visit(root)
-    return ok
+    return not diamond
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -20,6 +20,23 @@ def test_repr_matches_signature(tmp_path):
     assert repr(diamond) == diamond.signature
 
 
+def test_branch_no_diamond(tmp_path):
+    """Branching without shared nodes should not expand to a script."""
+    flow = Flow(cache=ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]), log=False)
+
+    @flow.task()
+    def add(x, y):
+        return x + y
+
+    @flow.task()
+    def square(z):
+        return z * z
+
+    node = square(add(square(1), square(2)))
+    expected = "square(z=add(x=square(z=1), y=square(z=2)))"
+    assert node.signature == expected
+
+
 def test_signature_key_canonicalization():
     def identity(x=None, **kw):
         return (x, kw)


### PR DESCRIPTION
## Summary
- flag diamond dependencies when a subgraph reuses the same signature
- ensure branching without shared nodes renders inline
- test branch detection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c52dea784832b843a5ac3d493e691