### PR TITLE
Simplify final expression output

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -261,19 +261,24 @@ def _build_script(root: Node):
     lines: List[str] = []
 
     for n in order:
-        key = getattr(n, "signature", None)
-        if key is None:
-            key = _render_call(n.fn, n.args, n.kwargs, canonical=True)
+        key = getattr(n, "signature", None) or _render_call(n.fn, n.args, n.kwargs, canonical=True)
         if key in sig2var:
             mapping[n] = sig2var[key]
+            if n is root:
+                lines.append(mapping[n])
             continue
-        var = f"n{len(sig2var)}"
-        sig2var[key] = var
-        mapping[n] = var
-        call = _render_call(n.fn, n.args, n.kwargs, canonical=True, mapping=mapping)
-        lines.append(f"{var} = {call}")
 
-    lines.append(mapping[root])
+        if n is root:
+            call = _render_call(n.fn, n.args, n.kwargs, canonical=True, mapping=mapping)
+            mapping[n] = call
+            lines.append(call)
+        else:
+            var = f"n{len(sig2var)}"
+            sig2var[key] = var
+            mapping[n] = var
+            call = _render_call(n.fn, n.args, n.kwargs, canonical=True, mapping=mapping)
+            lines.append(f"{var} = {call}")
+
     return "\n".join(lines), mapping
 
 

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -185,8 +185,7 @@ def test_repr_shared_nodes(tmp_path):
     script = repr(node).strip().splitlines()
     assert script == [
         "n0 = add(x=1, y=2)",
-        "n1 = combine(a=n0, b=n0)",
-        "n1",
+        "combine(a=n0, b=n0)",
     ]
 
 

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -63,7 +63,6 @@ def test_signature_script_dedup():
     lines = root.signature.strip().splitlines()
     assert lines == [
         "n0 = add(x=1, y=2)",
-        "n1 = add(x=n0, y=n0)",
-        "n1",
+        "add(x=n0, y=n0)",
     ]
 


### PR DESCRIPTION
## Summary
- refactor `_build_script` to inline the root node expression when possible
- retain variable reuse for duplicate nodes

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d05154818832bbc02a8415dbb73d3