### PR TITLE
Add Node.get method

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -21,6 +21,19 @@ def test_flow_example(tmp_path):
     assert flow.run(root) == 25
 
 
+def test_node_get(tmp_path):
+    flow = Flow(cache=ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]), log=False)
+
+    @flow.task()
+    def add(x, y):
+        return x + y
+
+    node = add(2, 3)
+    assert node.get() == 5
+    # Second call should reuse cache
+    assert node.get() == 5
+
+
 def test_cache_skips_execution(tmp_path):
     flow = Flow(cache=ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]), log=False)
     calls = []


### PR DESCRIPTION
## Summary
- add a `get` method to `Node` that runs the node via its associated `Flow`
- store the owning `Flow` on each `Node`
- ensure tasks pass the `Flow` into created `Node`s
- test the new `get` method

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d13d6aa20832baad7dd39f9c026af