### PR TITLE
Fix Flow.node signature handling

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import enum
 import hashlib
 import inspect
+import functools
 import os
 import threading
 import time
@@ -508,6 +509,7 @@ class Flow:
             fn._node_ignore = ignore_set
             sig_obj = inspect.signature(fn)
 
+            @functools.wraps(fn)
             def wrapper(*args, **kwargs):
                 bound = sig_obj.bind_partial(*args, **kwargs)
                 for name, val in self.config.defaults(fn.__name__).items():
@@ -522,9 +524,12 @@ class Flow:
                 self._registry[node.signature] = node
                 return node
 
+            wrapper.__signature__ = sig_obj
             return wrapper
 
         return deco
+
+    task = node
 
     def run(self, root: Node):
         return self.engine.run(root)


### PR DESCRIPTION
## Summary
- keep function metadata when wrapping node decorators
- expose Flow.task alias for user API

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1dcd88d4832bb179286abdb61115