### PR TITLE
feat: show live progress using rich

### DIFF
--- a/execution_status.py
+++ b/execution_status.py
@@ -1,5 +1,7 @@
 from node.node import Flow
 import time
+from rich.table import Table
+from rich.live import Live
 
 flow = Flow()
 
@@ -23,5 +25,19 @@ def inc(x: int) -> int:
 
 #
 if __name__ == "__main__":
-    node = square(add(square(2), square(2)))
-    print("Result:", node.get())
+    table = Table(show_header=False)
+    table.add_column("node")
+    table.add_column("status")
+
+    with Live(table, refresh_per_second=4) as live:
+        def log_status(node, dur, cached):
+            status = "cached" if cached else f"{dur:.1f}s"
+            table.add_row(node.signature, status)
+            live.update(table)
+
+        flow.engine.on_node_end = log_status
+
+        node = square(add(square(2), square(2)))
+        result = node.get()
+
+    print("Result:", result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "filelock>=3.18.0",
     "joblib>=1.5.1",
     "loguru>=0.7.3",
+    "rich>=14.0.0",
     "pytest>=8.4.0",
     "pyyaml>=6.0.2",
 ]


### PR DESCRIPTION
## Summary
- display node execution progress in `execution_status.py` with `rich`
- add `rich` to project dependencies

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d33a5d0a8832ba756a8c0b25eccb7