### PR TITLE
feat: show node status in real time

### DIFF
--- a/execution_status.py
+++ b/execution_status.py
@@ -1,5 +1,8 @@
 from node.node import Flow
 import time
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
+from node.node import _topo_order, Engine
 
 flow = Flow()
 
@@ -23,5 +26,30 @@ def inc(x: int) -> int:
 
 #
 if __name__ == "__main__":
+    console = Console()
     node = square(add(square(2), square(2)))
-    print("Result:", node.get())
+    order = _topo_order(node)
+
+    progress = Progress(
+        TextColumn("{task.fields[signature]}", justify="left"),
+        SpinnerColumn(),
+        TextColumn("{task.fields[status]}", justify="right"),
+        console=console,
+        refresh_per_second=5,
+    )
+    tasks = {n: progress.add_task("", signature=n.signature, status="pending", total=None) for n in order}
+
+    def on_start(n):
+        progress.update(tasks[n], status="running")
+
+    def on_end(n, dur, cached):
+        status = "cached" if cached else f"{dur:.1f}s"
+        progress.update(tasks[n], status=status, completed=1)
+
+    flow.engine.on_node_start = on_start
+    flow.engine.on_node_end = on_end
+
+    with progress:
+        result = node.get()
+
+    console.print("Result:", result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "filelock>=3.18.0",
     "joblib>=1.5.1",
     "loguru>=0.7.3",
+    "rich>=14.0.0",
     "pytest>=8.4.0",
     "pyyaml>=6.0.2",
 ]

--- a/src/node/node.py
+++ b/src/node/node.py
@@ -371,6 +371,7 @@ class Engine:
         executor: str = "thread",
         workers: int | None = None,
         log: bool = True,
+        on_node_start: Callable[[Node], None] | None = None,
         on_node_end: Callable[[Node, float, bool], None] | None = None,
         on_flow_end: Callable[[Node, float, int], None] | None = None,
     ):
@@ -379,6 +380,7 @@ class Engine:
         self.executor = executor
         self.workers = workers or (os.cpu_count() or 4)
         self.log = log
+        self.on_node_start = on_node_start
         self.on_node_end = on_node_end
         self.on_flow_end = on_flow_end
         self._can_save = hasattr(self.cache, "save_script")
@@ -394,6 +396,8 @@ class Engine:
         return v
 
     def _eval_node(self, n: Node):
+        if self.on_node_start:
+            self.on_node_start(n)
         hit, val = self.cache.get(n.signature)
         if hit:
             if self.on_node_end:


### PR DESCRIPTION
## Summary
- show live progress table in `execution_status.py`
- add `on_node_start` callback support in engine
- display progress with rich's `Progress`

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d33a5d0a8832ba756a8c0b25eccb7