### PR TITLE
Fix ruff and mypy errors

### DIFF
--- a/src/node/__init__.py
+++ b/src/node/__init__.py
@@ -1,1 +1,27 @@
+from typing import Optional
 
+from .node import (
+    ChainCache,
+    Config,
+    DiskJoblib,
+    Flow,
+    MemoryLRU,
+    Node,
+)
+
+try:  # optional rich dependency
+    from .reporters import RichReporter as _RichReporter
+
+    RichReporter: Optional[type] = _RichReporter
+except Exception:  # pragma: no cover - optional
+    RichReporter = None
+
+__all__ = [
+    "Node",
+    "ChainCache",
+    "MemoryLRU",
+    "DiskJoblib",
+    "Config",
+    "Flow",
+    "RichReporter",
+]


### PR DESCRIPTION
## Summary
- ensure RichReporter is optional to avoid hard dependency on rich
- add explicit exports for main classes
- improve mypy compliance with annotations
- add coverage ignore for reporters

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports .`
- `pytest --cov=src`
- `coverage report --fail-under=90` *(fails: total of 72 is less than fail-under=90)*

------
https://chatgpt.com/codex/tasks/task_e_684d84898504832b8b20584706f5cc84