### PR TITLE
Implement root cache short-circuit

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -467,6 +467,17 @@ class Engine:
     # ------------------------------------------------------------------
     def run(self, root: Node):
         self._exec_count = 0
+
+        hit, val = self.cache.get(root.signature)
+        if hit:
+            if self.on_node_start:
+                self.on_node_start(root)
+            if self.on_node_end:
+                self.on_node_end(root, 0.0, True)
+            if self.on_flow_end:
+                self.on_flow_end(root, 0.0, 0)
+            return val
+
         t0 = time.perf_counter()
         order = _topo_order(root)
 

--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -79,6 +79,11 @@ class _RichReporterCtx:
     def __exit__(self, exc_type, exc, tb):
         self._stop_event.set()
         self._t.join()
+        if self.engine._exec_count == 0:
+            for n in self.nodes:
+                if self.status[n][0] == "Pending":
+                    self.status[n][0] = "Skipped"
+            self.live.update(self.render())
         self.live.__exit__(exc_type, exc, tb)
         self.engine.on_node_start = self.orig_start
         self.engine.on_node_end = self.orig_end


### PR DESCRIPTION
## Summary
- return cached result immediately when running a flow
- mark nodes as skipped in reporter when root is cached

## Testing
- `pip install -e .`
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d8bad6d00832b8c6700856cf831b5