### PR TITLE
Add skip reporting and spinner update

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -468,14 +468,15 @@ class Engine:
     def run(self, root: Node):
         self._exec_count = 0
 
+        t0 = time.perf_counter()
         hit, val = self.cache.get(root.signature)
         if hit:
             if self.on_node_start:
                 self.on_node_start(root)
             if self.on_node_end:
-                self.on_node_end(root, 0.0, True)
+                self.on_node_end(root, time.perf_counter() - t0, True)
             if self.on_flow_end:
-                self.on_flow_end(root, 0.0, 0)
+                self.on_flow_end(root, time.perf_counter() - t0, 0)
             return val
 
         t0 = time.perf_counter()

--- a/src/node/node.py
+++ b/src/node/node.py
@@ -548,13 +548,21 @@ class Flow:
         executor: str = "thread",
         workers: int | None = None,
         log: bool = True,
-        reporter=None,
+        reporter=_Sentinel.MISS,
     ):
         self.config = config or Config()
         self.engine = Engine(cache=cache, executor=executor, workers=workers, log=log)
         self._registry: WeakValueDictionary[str, Node] = WeakValueDictionary()
         self.log = log
-        self.reporter = reporter
+        if reporter is _Sentinel.MISS:
+            try:  # defer import to avoid cycle
+                from .reporters import RichReporter as _RR
+            except Exception:
+                self.reporter = None
+            else:
+                self.reporter = _RR()
+        else:
+            self.reporter = reporter
 
     def node(
         self, *, ignore: Sequence[str] | None = None


### PR DESCRIPTION
## Summary
- use `rich` Spinner in reporter
- mark skipped nodes when entire flow is cached
- display grey `(skip)` label
- record duration when root node hits cache

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d947b77a4832bb57511ae4a17e214