### PR TITLE
Reduce redundancy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,20 @@
+# ruff: noqa: E402
 import sys
 from pathlib import Path
 
 # ensure src is on PYTHONPATH
 src_path = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(src_path))
+
+import pytest
+from node.node import ChainCache, DiskJoblib, Flow, MemoryLRU
+
+
+@pytest.fixture
+def flow_factory(tmp_path):
+    def _make(**kwargs) -> Flow:
+        cache = kwargs.pop("cache", ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]))
+        kwargs.setdefault("log", False)
+        return Flow(cache=cache, **kwargs)
+
+    return _make

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,8 +1,8 @@
-from node.node import Node, Flow, ChainCache, MemoryLRU, DiskJoblib
+from node.node import Node, ChainCache, MemoryLRU, DiskJoblib
 
 
-def test_repr_matches_signature(tmp_path):
-    flow = Flow(cache=ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]), log=False)
+def test_repr_matches_signature(flow_factory, tmp_path):
+    flow = flow_factory(cache=ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]))
 
     @flow.node()
     def add(x, y):
@@ -19,9 +19,9 @@ def test_repr_matches_signature(tmp_path):
     assert repr(diamond) == diamond.signature
 
 
-def test_branch_no_diamond(tmp_path):
+def test_branch_no_diamond(flow_factory, tmp_path):
     """Branching without shared nodes should not expand to a script."""
-    flow = Flow(cache=ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]), log=False)
+    flow = flow_factory(cache=ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]))
 
     @flow.node()
     def add(x, y):


### PR DESCRIPTION
## Summary
- introduce `_require_flow` to deduplicate flow checks
- simplify `DiskJoblib` path handling
- share Flow creation across tests via fixture
- refactor tests to use `flow_factory`

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e2b0ba038832b97e498a26558bc71