### PR TITLE
Fix RichReporter duplicate output

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -70,6 +70,10 @@ class _RichReporterCtx:
         self.live = Live(
             self.render(), refresh_per_second=self.reporter.refresh_per_second
         )
+        try:
+            self.live.console.clear()
+        except Exception:
+            pass
         self.live.__enter__()
         self._stop_event = threading.Event()
         self._t = threading.Thread(target=self._refresh_loop, daemon=True)


### PR DESCRIPTION
## Summary
- clear rich console before each run to avoid duplicated lines

## Testing
- `ruff format src/node/reporters.py`
- `ruff check src/node/reporters.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3885b914832b8a44d8dd69ebcd46