### PR TITLE
Improve DAG reuse

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -10,7 +10,7 @@ from rich.console import Group  # type: ignore[import]
 from rich.text import Text  # type: ignore[import]
 from rich.spinner import Spinner  # type: ignore[import]
 
-from .node import Node, _plan_dag, ChainCache
+from .node import Node, ChainCache, get_plan
 
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from .node import Engine
@@ -36,18 +36,10 @@ class _RichReporterCtx:
 
     # --------------------------------------------------------------
     def _build_lines(self, root: Node):
-        order, mapping, calls, dups = _plan_dag(root)
-        nodes: List[Node] = []
-        lines: List[str] = []
-
-        for n in order:
-            if n in dups and n is not root:
-                continue
-            call = calls[n]
-            lines.append(call if n is root else f"{mapping[n]} = {call}")
-            nodes.append(n)
-
-        return nodes, {n: label for n, label in zip(nodes, lines)}
+        plan = get_plan(root)
+        lines = list(plan.lines)
+        shown = list(plan.shown)
+        return shown, {n: label for n, label in zip(shown, lines)}
 
     # --------------------------------------------------------------
     def __enter__(self):


### PR DESCRIPTION
## Summary
- centralize plan generation with LRU caching
- compute node signatures via cached plans
- update reporter to use plan output
- support disabling in-memory cache for process executors
- preserve node signature once assigned and restore ValueError on cycles
- narrow plan-cache lock and keep signatures immutable

## Testing
- `ruff format --check .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e3b691c94832bb0dff36445549aed