### PR TITLE
Fix disk cache signatures

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -348,14 +348,14 @@ class Node:
 
     def _compute_lines(self) -> List[Tuple[str, str]]:
         merged = self._collect_lines()
-        mapping = {d: d.var for d in self.deps}
+        var_map = {d: d.var for d in self.deps}
         ignore = getattr(self.fn, "_node_ignore", ())
         call = _render_call(
             self.fn,
             self.args,
             self.kwargs,
             canonical=True,
-            mapping=mapping,
+            mapping=var_map,
             ignore=ignore,
         )
         merged[self._hash] = f"{self.var} = {call}"
@@ -373,12 +373,14 @@ class Node:
                 return self.__signature
 
         if _is_linear_chain(self):
+            var_map = {d: d.var for d in self.deps}
             ignore = getattr(self.fn, "_node_ignore", ())
             result = _render_call(
                 self.fn,
                 self.args,
                 self.kwargs,
                 canonical=True,
+                mapping=var_map,
                 ignore=ignore,
             )
         else:
@@ -390,14 +392,14 @@ class Node:
 
     def _non_linear_signature(self) -> str:
         self.lines()  # ensure populated
-        mapping = {d: d.var for d in self.deps}
+        var_map = {d: d.var for d in self.deps}
         ignore = getattr(self.fn, "_node_ignore", ())
         call = _render_call(
             self.fn,
             self.args,
             self.kwargs,
             canonical=True,
-            mapping=mapping,
+            mapping=var_map,
             ignore=ignore,
         )
         lines = [line for _, line in self.lines()[:-1]]

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -122,8 +122,9 @@ def test_build_script_repr(flow_factory):
         return z * z
 
     node = square(add(2, 3))
-    script = repr(node)
-    assert script.strip() == "square(z=add(x=2, y=3))"
+    script = repr(node).strip()
+    var = node.deps[0].var
+    assert script == f"square(z={var})"
 
 
 def test_linear_chain_repr(flow_factory):
@@ -142,7 +143,8 @@ def test_linear_chain_repr(flow_factory):
         return a
 
     node = f1(f2(f3(1)))
-    assert repr(node).strip() == "f1(a=f2(a=f3(a=1)))"
+    var = node.deps[0].var
+    assert repr(node).strip() == f"f1(a={var})"
 
 
 def test_diamond_dependency(flow_factory):

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -32,7 +32,8 @@ def test_branch_no_diamond(flow_factory, tmp_path):
         return z * z
 
     node = square(add(square(1), square(2)))
-    expected = "square(z=add(x=square(z=1), y=square(z=2)))"
+    var = node.deps[0].var
+    expected = f"square(z={var})"
     assert node.signature == expected
 
 


### PR DESCRIPTION
## Summary
- stabilize disk cache key generation by using node vars in linear chains
- adjust tests to match new signature style
- clarify var_map naming in signature helpers

## Testing
- `ruff format src/node/node.py`
- `ruff check src/node/node.py`
- `pytest tests/test_signatures.py tests/test_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684ee2a2af10832ba09afb565df83fdf