### PR TITLE
Switch caching to hash keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ print(result)  # 25
 ```python
 root = square(add(2, 3))
 print(repr(root))
-# square(z=add(x=2, y=3))
+# h_xxxxx = add(x=2, y=3)
+# h_yyyyy = square(z=h_xxxxx)
 ```
 
 ## 缓存与并行
 
-`Flow` 默认使用 `MemoryLRU` 和 `DiskJoblib` 组合成 `ChainCache`。缓存键即节点的 `signature` 字符串，磁盘缓存会以函数名创建子目录并尝试使用表达式作为文件名。这里的 `signature` 指节点的唯一字符串标识，由函数名及其参数构成，例如 `add(x=2, y=3)`：
+`Flow` 默认使用 `MemoryLRU` 和 `DiskJoblib` 组合成 `ChainCache`。缓存键为 `"<func>:<digest>"` 格式的哈希值，磁盘缓存统一存放在 `<func>/h_<digest6>.pkl`，同时写入 `h_<digest6>.py` 保存脚本：
 
 ```python
 from node.node import Flow, ChainCache, MemoryLRU, DiskJoblib
@@ -71,12 +72,11 @@ flow = Flow(
 )
 ```
 
-若表达式不适合作文件名，会回退到哈希值，并在同目录生成 `.py` 文件记录脚本。例如运行 `tutorial.py` 后可能出现：
+运行 `tutorial.py` 后将在缓存目录生成以下文件：
 
 ```
-.cache/inc/inc(x=3).pkl
-.cache/add/8be18ab9a193dbbc86b394bac923ab03.pkl
-.cache/add/8be18ab9a193dbbc86b394bac923ab03.py
+.cache/inc/h_abcdef.pkl
+.cache/inc/h_abcdef.py
 ```
 
 ## 配置对象

--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -98,9 +98,9 @@ class _RichReporterCtx:
     def _on_start(self, n: Node):
         mem_hit = disk_hit = False
         if self.caches:
-            mem_hit, _ = self.caches[0].get(n.signature)
+            mem_hit, _ = self.caches[0].get(n.cache_key)
         if not mem_hit and len(self.caches) > 1:
-            disk_hit, _ = self.caches[1].get(n.signature)
+            disk_hit, _ = self.caches[1].get(n.cache_key)
         if mem_hit:
             self.status[n][0] = "Cached hit in Memory"
         elif disk_hit:

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -32,9 +32,16 @@ def test_branch_no_diamond(flow_factory, tmp_path):
         return z * z
 
     node = square(add(square(1), square(2)))
-    var = node.deps[0].var
-    expected = f"square(z={var})"
-    assert node.signature == expected
+    lines = node.signature.strip().splitlines()
+    a = node.deps[0].deps[0].var
+    b = node.deps[0].deps[1].var
+    c = node.deps[0].var
+    assert lines == [
+        f"{a} = square(z=1)",
+        f"{b} = square(z=2)",
+        f"{c} = add(x={a}, y={b})",
+        f"{node.var} = square(z={c})",
+    ]
 
 
 def test_signature_key_canonicalization():
@@ -64,5 +71,5 @@ def test_signature_script_dedup():
     var = a.var
     assert lines == [
         f"{var} = add(x=1, y=2)",
-        f"add(x={var}, y={var})",
+        f"{root.var} = add(x={var}, y={var})",
     ]


### PR DESCRIPTION
## Summary
- rewrite caching to use hash-based keys
- simplify DiskJoblib paths and store readable scripts for every node
- update `Node.signature` and `repr` to show full assignment script
- adjust reporter and tests to new API
- document new behaviour in README

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eed7afbd4832b8a2a836d74ae22d7