### PR TITLE
Simplify node line generation

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -41,7 +41,7 @@ class _RichReporterCtx:
         h2node = {n._hash: n for n in order}
         nodes: List[Node] = []
         labels: Dict[Node, str] = {}
-        for h, line in root.lines():
+        for h, line in root.lines:
             n = h2node[h]
             nodes.append(n)
             label = line


### PR DESCRIPTION
## Summary
- remove `_signature_cache` and related lock
- update `Node.lines` to rely on `cached_property`
- clean up cache clearing logic

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fbeb3fa18832b8db5b0d720d3b5d4