### PR TITLE
Expand node key semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ print(result)  # 25
 ```python
 root = square(add(2, 3))
 print(repr(root))
-# h_xxxxx = add(x=2, y=3)
-# h_yyyyy = square(z=h_xxxxx)
+# add_89f9dde66a325c89ee8739040c6147ad = add(x=2, y=3)
+# square_7c3b8fad541e116101dc48cc17f9707b = square(z=add_89f9dde66a325c89ee8739040c6147ad)
 ```
 
 ## 缓存与并行
 
-`Flow` 默认使用 `MemoryLRU` 和 `DiskJoblib` 组合成 `ChainCache`。缓存键为 `"<func>:<digest>"` 格式的哈希值，磁盘缓存统一存放在 `<func>/h_<digest6>.pkl`，同时写入 `h_<digest6>.py` 保存脚本：
+`Flow` 默认使用 `MemoryLRU` 和 `DiskJoblib` 组合成 `ChainCache`。缓存键为 `"<func>_<digest>"` 格式的哈希值，磁盘缓存统一存放在 `<func>/<digest>.pkl`，同时写入 `<digest>.py` 保存脚本：
 
 ```python
 from node.node import Flow, ChainCache, MemoryLRU, DiskJoblib
@@ -75,8 +75,8 @@ flow = Flow(
 运行 `tutorial.py` 后将在缓存目录生成以下文件：
 
 ```
-.cache/inc/h_abcdef.pkl
-.cache/inc/h_abcdef.py
+.cache/inc/89f9dde66a325c89ee8739040c6147ad.pkl
+.cache/inc/89f9dde66a325c89ee8739040c6147ad.py
 ```
 
 ## 配置对象

--- a/src/node/node.py
+++ b/src/node/node.py
@@ -157,10 +157,12 @@ class DiskJoblib(Cache):
 
     def _path(self, key: str, ext: str = ".pkl") -> Path:
         """Return the cache file path for ``key``."""
-        fn, hash_key = key.split(":", 1)
+        parts = key.rsplit("_", 1)
+        fn = parts[0]
+        hash_key = parts[1]
         sub = self.root / fn
         sub.mkdir(parents=True, exist_ok=True)
-        return sub / (f"h_{hash_key[:6]}" + ext)
+        return sub / (hash_key + ext)
 
     def get(self, key: str):
         p = self._path(key)
@@ -183,7 +185,7 @@ class DiskJoblib(Cache):
                     p.unlink()
 
     def save_script(self, node: "Node"):
-        p = self._path(node.cache_key, ".py")
+        p = self._path(node.key, ".py")
         p.write_text(repr(node) + "\n")
 
 
@@ -303,43 +305,35 @@ class Node:
 
     @property
     def hash(self) -> int:
-        return getattr(self, "_hash", id(self))
+        return self._hash
+
+    @property
+    def key(self) -> str:
+        """Unique identifier combining function name and hash."""
+        return f"{self.fn.__name__}_{self._hash:x}"
 
     def __lt__(self, other: "Node") -> bool:
         return self.hash < other.hash
-
-    @property
-    def var(self) -> str:
-        hex_str = f"{self._hash:032x}"
-        return f"h_{hex_str[:6]}"
-
-    @property
-    def cache_key(self) -> str:
-        """Unique deterministic key used for caching."""
-        return f"{self.fn.__name__}:{self._hash:032x}"
 
     @functools.cached_property
     def lines(self) -> List[Tuple[int, str]]:
         """Return script lines for this node without trailing call."""
         with self._lock:
-            return self._compute_lines()
-
-    def _compute_lines(self) -> List[Tuple[int, str]]:
-        order = self.order
-        lines: List[Tuple[int, str]] = []
-        for node in order:
-            var_map = {d: d.var for d in node.deps}
-            ignore = getattr(node.fn, "_node_ignore", ())
-            call = _render_call(
-                node.fn,
-                node.args,
-                node.kwargs,
-                canonical=True,
-                mapping=var_map,
-                ignore=ignore,
-            )
-            lines.append((node._hash, f"{node.var} = {call}"))
-        return lines
+            order = self.order
+            lines: List[Tuple[int, str]] = []
+            for node in order:
+                var_map = {d: d.key for d in node.deps}
+                ignore = getattr(node.fn, "_node_ignore", ())
+                call = _render_call(
+                    node.fn,
+                    node.args,
+                    node.kwargs,
+                    canonical=True,
+                    mapping=var_map,
+                    ignore=ignore,
+                )
+                lines.append((node._hash, f"{node.key} = {call}"))
+            return lines
 
     @functools.cached_property
     def order(self) -> List["Node"]:
@@ -353,7 +347,7 @@ class Node:
         return self._require_flow().run(self)
 
     def delete_cache(self) -> None:
-        self._require_flow().engine.cache.delete(self.cache_key)
+        self._require_flow().engine.cache.delete(self.key)
 
     def generate(self) -> None:
         """Compute and cache this node without returning the value."""
@@ -455,7 +449,7 @@ class Engine:
     # ------------------------------------------------------------------
     def _resolve(self, v):
         if isinstance(v, Node):
-            hit, val = self.cache.get(v.cache_key)
+            hit, val = self.cache.get(v.key)
             return val if hit else None
         return v
 
@@ -463,7 +457,7 @@ class Engine:
         start = time.perf_counter()
         if self.on_node_start:
             self.on_node_start(n)
-        hit, val = self.cache.get(n.cache_key)
+        hit, val = self.cache.get(n.key)
         if hit:
             dur = time.perf_counter() - start
             if self.on_node_end:
@@ -473,7 +467,7 @@ class Engine:
         args = [self._resolve(a) for a in n.args]
         kwargs = {k: self._resolve(v) for k, v in n.kwargs.items()}
         val = n.fn(*args, **kwargs)
-        self.cache.put(n.cache_key, val)
+        self.cache.put(n.key, val)
         if self._can_save:
             self.cache.save_script(n)
         dur = time.perf_counter() - start
@@ -488,7 +482,7 @@ class Engine:
         self._exec_count = 0
 
         t0 = time.perf_counter()
-        hit, val = self.cache.get(root.cache_key)
+        hit, val = self.cache.get(root.key)
         if hit:
             if self.on_node_start:
                 self.on_node_start(root)
@@ -544,7 +538,7 @@ class Engine:
         self.on_node_end = orig_end
         if self.on_flow_end:
             self.on_flow_end(root, wall, self._exec_count)
-        return self.cache.get(root.cache_key)[1]
+        return self.cache.get(root.key)[1]
 
 
 # ----------------------------------------------------------------------

--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -106,9 +106,9 @@ class _RichReporterCtx:
     def _on_start(self, n: Node):
         mem_hit = disk_hit = False
         if self.caches:
-            mem_hit, _ = self.caches[0].get(n.cache_key)
+            mem_hit, _ = self.caches[0].get(n.key)
         if not mem_hit and len(self.caches) > 1:
-            disk_hit, _ = self.caches[1].get(n.cache_key)
+            disk_hit, _ = self.caches[1].get(n.key)
         if mem_hit:
             self.status[n][0] = "Cached hit in Memory"
         elif disk_hit:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -123,10 +123,10 @@ def test_build_script_repr(flow_factory):
 
     node = square(add(2, 3))
     script = repr(node).strip().splitlines()
-    var = node.deps[0].var
+    var = node.deps[0].key
     assert script == [
         f"{var} = add(x=2, y=3)",
-        f"{node.var} = square(z={var})",
+        f"{node.key} = square(z={var})",
     ]
 
 
@@ -147,12 +147,12 @@ def test_linear_chain_repr(flow_factory):
 
     node = f1(f2(f3(1)))
     lines = repr(node).strip().splitlines()
-    v1 = node.deps[0].deps[0].var
-    v2 = node.deps[0].var
+    v1 = node.deps[0].deps[0].key
+    v2 = node.deps[0].key
     assert lines == [
         f"{v1} = f3(a=1)",
         f"{v2} = f2(a={v1})",
-        f"{node.var} = f1(a={v2})",
+        f"{node.key} = f1(a={v2})",
     ]
 
 
@@ -223,10 +223,10 @@ def test_repr_shared_nodes(flow_factory):
 
     node = combine(add(1, 2), add(1, 2))
     script = repr(node).strip().splitlines()
-    var = node.deps[0].var
+    var = node.deps[0].key
     assert script == [
         f"{var} = add(x=1, y=2)",
-        f"{node.var} = combine(a={var}, b={var})",
+        f"{node.key} = combine(a={var}, b={var})",
     ]
 
 
@@ -261,13 +261,13 @@ def test_chaincache_promotion(flow_factory, tmp_path):
 
     node = add(2, 3)
     flow.run(node)
-    assert node.cache_key in mem._lru
+    assert node.key in mem._lru
 
     mem._lru.clear()
-    assert node.cache_key not in mem._lru
+    assert node.key not in mem._lru
 
     flow.run(node)
-    assert node.cache_key in mem._lru
+    assert node.key in mem._lru
 
 
 def test_parallel_execution(flow_factory):
@@ -426,14 +426,14 @@ def test_delete_cache(flow_factory, tmp_path):
 
     node = add(1, 2)
     assert flow.run(node) == 3
-    assert node.cache_key in mem._lru
+    assert node.key in mem._lru
 
-    p = disk._path(node.cache_key)
+    p = disk._path(node.key)
     assert p.exists()
 
     node.delete_cache()
 
-    assert node.cache_key not in mem._lru
+    assert node.key not in mem._lru
     assert not p.exists()
 
     assert flow.run(node) == 3

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -33,14 +33,14 @@ def test_branch_no_diamond(flow_factory, tmp_path):
 
     node = square(add(square(1), square(2)))
     lines = node.signature.strip().splitlines()
-    a = node.deps[0].deps[0].var
-    b = node.deps[0].deps[1].var
-    c = node.deps[0].var
+    a = node.deps[0].deps[0].key
+    b = node.deps[0].deps[1].key
+    c = node.deps[0].key
     assert lines == [
         f"{a} = square(z=1)",
         f"{b} = square(z=2)",
         f"{c} = add(x={a}, y={b})",
-        f"{node.var} = square(z={c})",
+        f"{node.key} = square(z={c})",
     ]
 
 
@@ -68,8 +68,8 @@ def test_signature_script_dedup():
     root = Node(add, (a, b))
 
     lines = root.signature.strip().splitlines()
-    var = a.var
+    var = a.key
     assert lines == [
         f"{var} = add(x=1, y=2)",
-        f"{root.var} = add(x={var}, y={var})",
+        f"{root.key} = add(x={var}, y={var})",
     ]


### PR DESCRIPTION
## Summary
- fix `_path` parsing when function names contain underscores
- remove `var`, `cache_key` and `hex` attributes
- use `Node.key` everywhere and simplify script generation
- drop the `h_` prefix from disk cache files
- adjust docs and tests for new key semantics

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fd9ea2d38832ba3216874f58b53b4