### PR TITLE
Remove redundant code

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ from node.node import ChainCache, DiskJoblib, Flow, MemoryLRU
 def flow_factory(tmp_path):
     def _make(**kwargs) -> Flow:
         cache = kwargs.pop("cache", ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]))
-        kwargs.setdefault("log", False)
         return Flow(cache=cache, **kwargs)
 
     return _make


### PR DESCRIPTION
## Summary
- drop unused `log` parameter in Engine/Flow
- delete unused `_merge_lines` helper
- simplify Node hashing
- adjust test fixture

## Testing
- `ruff check .`
- `mypy src/node tests`
- `pytest --cov=src`
- `coverage report --fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_684fe7984080832b8165010b7e0197a6