### PR TITLE
Add SmartReporter

### DIFF
--- a/src/node/__init__.py
+++ b/src/node/__init__.py
@@ -10,11 +10,16 @@ from .node import (
 )
 
 try:  # optional rich dependency
-    from .reporters import RichReporter as _RichReporter
+    from .reporters import (
+        RichReporter as _RichReporter,
+        SmartReporter as _SmartReporter,
+    )
 
     RichReporter: Optional[type] = _RichReporter
+    SmartReporter: Optional[type] = _SmartReporter
 except Exception:  # pragma: no cover - optional
     RichReporter = None
+    SmartReporter = None
 
 __all__ = [
     "Node",
@@ -24,4 +29,5 @@ __all__ = [
     "Config",
     "Flow",
     "RichReporter",
+    "SmartReporter",
 ]

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -6,6 +6,7 @@ import yaml  # type: ignore[import]
 import pytest
 import joblib  # type: ignore[import]
 from node.node import Node, Config, ChainCache, MemoryLRU, DiskJoblib
+from node.reporters import SmartReporter
 
 
 def test_flow_example(flow_factory):
@@ -500,3 +501,15 @@ def test_deep_chain_signature(flow_factory):
         node = inc(node)
 
     assert flow.run(node) == 201
+
+
+def test_smart_reporter_runs(flow_factory):
+    flow = flow_factory()
+
+    @flow.node()
+    def add(x, y):
+        return x + y
+
+    rep = SmartReporter(refresh=10)
+    node = add(1, 2)
+    assert flow.run(node, reporter=rep) == 3


### PR DESCRIPTION
## Summary
- add new SmartReporter implementation with queue-driven rendering
- expose SmartReporter from package
- test running Flow with SmartReporter
- improve SmartReporter header

## Testing
- `ruff format --check .`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68503aee90d4832ba64391019e36bb81