### PR TITLE
Add SmartReporter

### DIFF
--- a/src/node/__init__.py
+++ b/src/node/__init__.py
@@ -10,11 +10,16 @@ from .node import (
 )
 
 try:  # optional rich dependency
-    from .reporters import RichReporter as _RichReporter
+    from .reporters import (
+        RichReporter as _RichReporter,
+        SmartReporter as _SmartReporter,
+    )
 
     RichReporter: Optional[type] = _RichReporter
+    SmartReporter: Optional[type] = _SmartReporter
 except Exception:  # pragma: no cover - optional
     RichReporter = None
+    SmartReporter = None
 
 __all__ = [
     "Node",
@@ -24,4 +29,5 @@ __all__ = [
     "Config",
     "Flow",
     "RichReporter",
+    "SmartReporter",
 ]

--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 # coverage: ignore-file
 
-from typing import Dict, List, TYPE_CHECKING
+from typing import Dict, Deque, List, TYPE_CHECKING
 import time
 import threading
 
@@ -16,13 +16,18 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
 )
+from rich.layout import Layout  # type: ignore[import]
+from rich.panel import Panel  # type: ignore[import]
+from rich.table import Table  # type: ignore[import]
+from queue import Empty, SimpleQueue
+from collections import deque
 
 from .node import Node, ChainCache, _topo_order
 
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from .node import Engine
 
-__all__ = ["RichReporter"]
+__all__ = ["RichReporter", "SmartReporter"]
 
 
 class RichReporter:
@@ -205,3 +210,166 @@ class _RichReporterCtx:
 
         rows.extend(self._format_line(n, frame) for n in nodes)
         return Group(*rows)
+
+
+class SmartReporter:
+    """Concurrent-safe reporter with compact UI."""
+
+    def __init__(self, refresh: int = 20, window: int = 20) -> None:
+        self.refresh = refresh
+        self.window = window
+
+    def attach(self, engine: "Engine", root: Node):
+        return _SmartCtx(self, engine, root)
+
+
+class _SmartCtx:
+    def __init__(self, cfg: SmartReporter, engine, root: Node) -> None:
+        self.cfg = cfg
+        self.engine = engine
+        self.root = root
+        self.q: SimpleQueue = SimpleQueue()
+        self.running: Dict[str, float] = {}
+        self.done: Deque[tuple[str, float, bool]] = deque(maxlen=cfg.window)
+        self.stats = {"total": len(root.order), "done": 0, "cached": 0}
+        self.cache_time = 0.0
+        self.exec_time = 0.0
+        self.all_exec: List[tuple[str, float]] = []
+
+    # ------------------------------------------------------------------
+    def __enter__(self):
+        self.orig_start = self.engine.on_node_start
+        self.orig_end = self.engine.on_node_end
+        self.engine.on_node_start = self._start
+        self.engine.on_node_end = self._end
+        self.progress = Progress(
+            BarColumn(bar_width=None),
+            TaskProgressColumn(),
+            TimeElapsedColumn(),
+            transient=False,
+            refresh_per_second=self.cfg.refresh,
+        )
+        self.bar = self.progress.add_task("flow", total=self.stats["total"])
+        self.live = Live(self._render(), refresh_per_second=self.cfg.refresh)
+        self.live.__enter__()
+        self._stop = threading.Event()
+        self.t = threading.Thread(target=self._ui_loop, daemon=True)
+        self.t.start()
+        return self
+
+    # ------------------------------------------------------------------
+    def __exit__(self, exc_type, exc, tb):
+        self._stop.set()
+        self.t.join()
+        self.live.update(self._render(final=True))
+        self.live.__exit__(exc_type, exc, tb)
+        self.engine.on_node_start = self.orig_start
+        self.engine.on_node_end = self.orig_end
+
+    # ------------------------------------------------------------------
+    def _start(self, n: Node) -> None:
+        hit, _ = self.engine.cache.get(n.key)
+        self.q.put(("start", n.key, time.perf_counter(), hit))
+        if self.orig_start:
+            self.orig_start(n)
+
+    def _end(self, n: Node, dur: float, cached: bool) -> None:
+        self.q.put(("end", n.key, dur, cached))
+        if self.orig_end:
+            self.orig_end(n, dur, cached)
+
+    # ------------------------------------------------------------------
+    def _ui_loop(self) -> None:
+        sleep = 1.0 / self.cfg.refresh
+        while not self._stop.is_set():
+            self._drain_queue()
+            self.live.update(self._render())
+            time.sleep(sleep)
+        self._drain_queue()
+        self.live.update(self._render())
+
+    def _drain_queue(self) -> None:
+        while True:
+            try:
+                event = self.q.get_nowait()
+            except Empty:
+                break
+            if event[0] == "start":
+                _, k, ts, hit = event
+                if not hit:
+                    self.running[k] = ts
+            else:
+                self._handle_end(event)
+
+    def _handle_end(self, event: tuple) -> None:
+        _, k, dur, cached = event
+        self.running.pop(k, None)
+        self.done.appendleft((k, dur, cached))
+        self.stats["done"] += 1
+        self.progress.advance(self.bar)
+        if cached:
+            self.stats["cached"] += 1
+            self.cache_time += dur
+        else:
+            self.exec_time += dur
+            self.all_exec.append((k, dur))
+
+    # ------------------------------------------------------------------
+    def _render(self, final: bool = False):
+        layout = Layout()
+        layout.split(
+            Layout(self._make_header(), name="header", size=1),
+            Layout(self.progress, name="prog", size=3),
+            Layout(name="body"),
+        )
+        if final:
+            layout["body"].update(self._table_all_exec())
+            return layout
+        body = Layout()
+        body.split_row(
+            Layout(self._table_running(), name="running"),
+            Layout(self._table_recent(), name="recent"),
+        )
+        layout["body"].update(body)
+        return layout
+
+    def _make_header(self):
+        s = self.stats
+        hit = s["cached"]
+        new = len(self.all_exec)
+        remain = s["total"] - s["done"]
+        eta = self.exec_time / new * remain if new else 0.0
+        text = Text()
+        text.append(f"⚡Cache hit: {hit} [{self.cache_time:.2f}s]    ", "cyan")
+        text.append(f"✨New: {new} [{self.exec_time:.1f}s]    ", "magenta")
+        if remain:
+            text.append(f"✔Remain: {remain} [ETA: {eta:.0f} s]", "green")
+        return text
+
+    def _table_running(self):
+        tab = Table(title=f"Running ({len(self.running)})", box=None, expand=True)
+        tab.add_column("Node", overflow="fold")
+        tab.add_column("Elapsed")
+        now = time.perf_counter()
+        for k, ts in list(self.running.items())[: self.cfg.window]:
+            tab.add_row(k, f"{now - ts:.2f}s")
+        return Panel(tab)
+
+    def _table_recent(self):
+        tab = Table(title="Recent", box=None, expand=True)
+        tab.add_column("Node", overflow="fold")
+        tab.add_column("Dur")
+        tab.add_column("Type")
+        for k, dur, cached in self.done:
+            style = "cyan" if cached else "green"
+            typ = "cached" if cached else "done"
+            tab.add_row(Text(k, style=style), f"{dur:.2f}s", typ)
+        return Panel(tab)
+
+    def _table_all_exec(self):
+        tab = Table(title="Executed", box=None, expand=True)
+        tab.add_column("Node", overflow="fold")
+        tab.add_column("Dur")
+        for k, dur in self.all_exec:
+            tab.add_row(k, f"{dur:.2f}s")
+        return Panel(tab)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -6,6 +6,7 @@ import yaml  # type: ignore[import]
 import pytest
 import joblib  # type: ignore[import]
 from node.node import Node, Config, ChainCache, MemoryLRU, DiskJoblib
+from node.reporters import SmartReporter
 
 
 def test_flow_example(flow_factory):
@@ -500,3 +501,15 @@ def test_deep_chain_signature(flow_factory):
         node = inc(node)
 
     assert flow.run(node) == 201
+
+
+def test_smart_reporter_runs(flow_factory):
+    flow = flow_factory()
+
+    @flow.node()
+    def add(x, y):
+        return x + y
+
+    rep = SmartReporter(refresh=10)
+    node = add(1, 2)
+    assert flow.run(node, reporter=rep) == 3


### PR DESCRIPTION
## Summary
- add new SmartReporter implementation with queue-driven rendering
- expose SmartReporter from package
- test running Flow with SmartReporter
- enhance SmartReporter header with execution stats

## Testing
- `pip install -e .`
- `ruff format --check .`
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503aee90d4832ba64391019e36bb81