### PR TITLE
feat: refine reporter header

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -147,14 +147,19 @@ class _RichReporterCtx:
         remain = self.total - done - len(self.running)
         avg = (exec_time) / self.execs if self.execs else 0.0
         eta = int(remain * avg)
-        parts = [
-            ("⚡ Cache ", "bold"),
-            (f"{self.hits} "),
-            (f"[{self.hit_time:.1f}s]", "gray50"),
-            ("\t⭐ Create ", "bold"),
-            (f"{int(self.execs)} "),
-            (f"[{exec_time:.1f}s]", "gray50"),
-        ]
+        parts = []
+        if self.hits:
+            parts += [
+                ("⚡ Cache ", "bold"),
+                (f"{self.hits} "),
+                (f"[{self.hit_time:.1f}s]", "gray50"),
+            ]
+        if self.execs:
+            parts += [
+                ("\t⭐ Create ", "bold"),
+                (f"{int(self.execs)} "),
+                (f"[{exec_time:.1f}s]", "gray50"),
+            ]
         if not final:
             parts += [
                 ("\t📋 Queue ", "bold"),

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -1,0 +1,31 @@
+from node.node import Flow
+from node.reporters import RichReporter
+
+
+def _make_ctx(hits=0, execs=0):
+    flow = Flow()
+
+    @flow.node()
+    def dummy():
+        return None
+
+    root = dummy()
+    ctx = RichReporter().attach(flow.engine, root)
+    ctx.total = 1
+    ctx.hits = hits
+    ctx.execs = execs
+    return ctx
+
+
+def test_header_omits_cache_when_zero():
+    ctx = _make_ctx(hits=0, execs=1)
+    header = ctx._header(final=False).plain
+    assert "⚡ Cache" not in header
+    assert "⭐ Create" in header
+
+
+def test_header_omits_create_when_zero():
+    ctx = _make_ctx(hits=1, execs=0)
+    header = ctx._header(final=False).plain
+    assert "⭐ Create" not in header
+    assert "⚡ Cache" in header


### PR DESCRIPTION
## Summary
- hide cache/create info in RichReporter when counts are zero
- test reporter header output

## Testing
- `ruff check src tests`
- `mypy src tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68542f839dd8832b93fea216a979cc02