### PR TITLE
Optimize render_call by reusing bound args

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -124,7 +124,7 @@ class _RichReporterCtx:
         if self.cfg.show_script_line:
             call = n.lines[-1][-1]
         else:
-            call = _render_call(n.fn, n.args, n.kwargs)
+            call = _render_call(n.fn, n.args, n.kwargs, bound_args=n._bound_args)
         self.q.put(("start", n.key, call, time.perf_counter()))
         if self.orig_start:
             self.orig_start(n)

--- a/tests/test_bound_args.py
+++ b/tests/test_bound_args.py
@@ -1,0 +1,23 @@
+import inspect
+
+
+def test_render_call_uses_bound_args(flow_factory, monkeypatch):
+    flow = flow_factory()
+
+    @flow.node()
+    def add(x, y):
+        return x + y
+
+    root = add(1, 2)
+    # patch after node creation so __init__ already bound signature
+    calls = 0
+    original = inspect.signature
+
+    def wrapper(fn):
+        nonlocal calls
+        calls += 1
+        return original(fn)
+
+    monkeypatch.setattr(inspect, "signature", wrapper)
+    _ = root.lines
+    assert calls == 0


### PR DESCRIPTION
## Summary
- reuse `Node._bound_args` when rendering calls
- pass bound args from `RichReporter`
- cover bound arg reuse with a unit test

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855052cfd1c832bbabfc4b0d7c1819e