### PR TITLE
Add Syntax highlighting to reporter labels

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -11,6 +11,7 @@ from rich.live import Live  # type: ignore[import]
 from rich.console import Group  # type: ignore[import]
 from rich.text import Text  # type: ignore[import]
 from rich.spinner import Spinner  # type: ignore[import]
+from rich.syntax import Syntax  # type: ignore[import]
 
 from .node import Node, _render_call
 
@@ -125,7 +126,8 @@ class _RichReporterCtx:
             call = n.lines[-1][-1]
         else:
             call = _render_call(n.fn, n.args, n.kwargs)
-        self.q.put(("start", n.key, call, time.perf_counter()))
+        label = Syntax(call, "python")
+        self.q.put(("start", n.key, label, time.perf_counter()))
         if self.orig_start:
             self.orig_start(n)
 
@@ -226,5 +228,11 @@ class _RichReporterCtx:
         icon = str(self.spinner.render(now))
         for label, ts in list(self.running.values()):
             dur = self._format_dur(now - ts)
-            out.append(Text.assemble(f"{icon} {label} ", (f"[{dur}]", "gray50")))
+            out.append(
+                Group(
+                    Text(icon + " "),
+                    label,
+                    Text(f" [{dur}]", style="gray50"),
+                )
+            )
         return Group(*out)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -36,3 +36,15 @@ def test_format_duration():
     assert ctx._format_dur(5) == "5.0s"
     assert ctx._format_dur(65) == "1m 5s"
     assert ctx._format_dur(3661) == "1h 1m 1s"
+
+
+def test_start_uses_syntax():
+    ctx = _make_ctx()
+    ctx.__enter__()
+    ctx._start(ctx.root)
+    ctx._drain()
+    label, _ = ctx.running[ctx.root.key]
+    ctx.__exit__(None, None, None)
+    from rich.syntax import Syntax
+
+    assert isinstance(label, Syntax)


### PR DESCRIPTION
## Summary
- highlight code labels in `RichReporter` using `rich.syntax.Syntax`
- test that `_start` stores `Syntax`

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685504793f5c832bbd86b270635420f7