### PR TITLE
Remove redundant argument storage

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -124,7 +124,7 @@ class _RichReporterCtx:
         if self.cfg.show_script_line:
             call = n.lines[-1][-1]
         else:
-            call = _render_call(n.fn, n.args, n.kwargs)
+            call = _render_call(n.fn, n.args, n.kwargs, bound=n.bound_args)
         self.q.put(("start", n.key, call, time.perf_counter()))
         if self.orig_start:
             self.orig_start(n)


### PR DESCRIPTION
## Summary
- avoid storing `bound_args` on `Node`
- compute canonical args on demand
- cache bound arguments for reuse in render functions

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68550506a150832b8f35e183e5d3676b