### PR TITLE
Implement cache management API

### DIFF
--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -20,15 +20,15 @@ def _make_ctx(hits=0, execs=0):
 def test_header_omits_cache_when_zero():
     ctx = _make_ctx(hits=0, execs=1)
     header = ctx._header(final=False).plain
-    assert "⚡️Cache" not in header
-    assert "✨️Create" in header
+    assert "⚡️ Cache" not in header
+    assert "✨️ Create" in header
 
 
 def test_header_omits_create_when_zero():
     ctx = _make_ctx(hits=1, execs=0)
     header = ctx._header(final=False).plain
-    assert "✨️Create" not in header
-    assert "⚡️Cache" in header
+    assert "✨️ Create" not in header
+    assert "⚡️ Cache" in header
 
 
 def test_format_duration():
@@ -45,6 +45,6 @@ def test_start_uses_syntax():
     ctx._drain()
     label, _ = ctx.running[ctx.root.key]
     ctx.__exit__(None, None, None)
-    from rich.syntax import Syntax
+    from rich.text import Text
 
-    assert isinstance(label, Syntax)
+    assert isinstance(label, Text)


### PR DESCRIPTION
## Summary
- add Node.create and Node.delete APIs
- implement Flow.create, Flow.generate and Flow.delete
- adjust reporter tests for updated formatting
- test cache overwrite via Node.create

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68555789b188832bac46067914739590