### PR TITLE
Add per-node worker limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Node 是一个轻量级、零依赖的 DAG 流程库，适合在脚本或小型�
 
 - **任务装饰器**：普通函数经 `@flow.node()` 包装后即可组成 DAG，可用 `ignore` 参数排除大型对象。
 - **两级缓存**：默认同时启用内存 LRU 与磁盘缓存，避免重复计算。
-- **并行执行**：支持线程或进程池，`workers` 参数控制并发量。
+- **并行执行**：支持线程或进程池，可在装饰器中用 `workers` 指定单个任务的并发数。
 - **脚本表示**：任意节点的 `repr()` 都会生成等效的 Python 调用脚本。
 - **配置系统**：通过 `Config` 对象集中管理任务默认参数，支持从 YAML 加载。
 - **回调钩子**：`on_node_end` 与 `on_flow_end` 可用来收集统计信息。
@@ -30,7 +30,7 @@ from node.node import Flow
 flow = Flow()
 
 
-@flow.node()
+@flow.node(workers=2)
 def add(x, y):
     return x + y
 
@@ -69,7 +69,7 @@ from node.node import Flow, ChainCache, MemoryLRU, DiskJoblib
 flow = Flow(
     cache=ChainCache([MemoryLRU(), DiskJoblib(".cache")]),
     executor="thread",  # 或 "process"
-    workers=4,
+    default_workers=4,
 )
 ```
 

--- a/bench_flow.py
+++ b/bench_flow.py
@@ -9,7 +9,7 @@ from src.node import Flow, Config
 def build_flow() -> Tuple[Any, Any]:
     """Build a 400x400 node grid DAG."""
 
-    flow = Flow(config=Config(), executor="thread", workers=8)
+    flow = Flow(config=Config(), executor="thread", default_workers=8)
 
     @flow.node()
     def slow_mul(a: int, b: int) -> int:

--- a/src/node/node.py
+++ b/src/node/node.py
@@ -529,12 +529,22 @@ class Engine:
         ts = TopologicalSorter({n: n.deps for n in order})
         ts.prepare()
 
+        sems: Dict[Callable[..., Any], threading.Semaphore] = {}
+        for node in order:
+            workers = getattr(node.fn, "_node_workers", 1)
+            if workers == -1:
+                workers = os.cpu_count() or 1
+            if node.fn not in sems:
+                sems[node.fn] = threading.Semaphore(workers)
+
         fut_map = {}
         with pool_cls(max_workers=self.workers) as pool:
 
             def submit(node):
                 if self.executor == "thread":
-                    fut_map[pool.submit(self._eval_node, node)] = node
+                    sem = sems[node.fn]
+                    sem.acquire()
+                    fut_map[pool.submit(self._eval_node, node)] = (node, sem)
                 else:
                     start = time.perf_counter()
                     if self.on_node_start:
@@ -547,8 +557,10 @@ class Engine:
                         return
                     args = [self._resolve(a) for a in node.args]
                     kwargs = {k: self._resolve(v) for k, v in node.kwargs.items()}
+                    sem = sems[node.fn]
+                    sem.acquire()
                     fut = pool.submit(_call_fn, node.fn, args, kwargs)
-                    fut_map[fut] = (node, start)
+                    fut_map[fut] = (node, start, sem)
 
             for n in ts.get_ready():
                 submit(n)
@@ -558,10 +570,11 @@ class Engine:
                 for fut in done:
                     info = fut_map.pop(fut)
                     if self.executor == "thread":
-                        node = info
+                        node, sem = info
                         fut.result()  # re-raise errors immediately
+                        sem.release()
                     else:
-                        node, start = info
+                        node, start, sem = info
                         val = fut.result()
                         self.cache.put(node.key, val)
                         if self._can_save:
@@ -571,6 +584,7 @@ class Engine:
                             self.on_node_end(node, dur, False)
                         with self._lock:
                             self._exec_count += 1
+                        sem.release()
                     ts.done(node)
                 for n in ts.get_ready():
                     submit(n)
@@ -601,11 +615,16 @@ class Flow:
         config: Config | None = None,
         cache: Cache | None = None,
         executor: str = "thread",
-        workers: int | None = None,
+        default_workers: int = 1,
         reporter: Optional[Any] = None,
     ):
         self.config = config or Config()
-        self.engine = Engine(cache=cache, executor=executor, workers=workers)
+        self.default_workers = default_workers
+        self.engine = Engine(
+            cache=cache,
+            executor=executor,
+            workers=default_workers,
+        )
         self._registry: WeakValueDictionary[Node, Node] = WeakValueDictionary()
         if reporter is None:
             try:  # defer import to avoid cycle
@@ -618,7 +637,7 @@ class Flow:
             self.reporter = reporter
 
     def node(
-        self, *, ignore: Sequence[str] | None = None
+        self, *, ignore: Sequence[str] | None = None, workers: int | None = None
     ) -> Callable[[Callable[..., Any]], Callable[..., Node]]:
         ignore_set = set(ignore or [])
 
@@ -626,6 +645,11 @@ class Flow:
             setattr(fn, "_node_ignore", ignore_set)  # type: ignore[attr-defined]
             sig_obj = inspect.signature(fn)
             setattr(fn, "_node_sig", sig_obj)
+            setattr(
+                fn,
+                "_node_workers",
+                workers if workers is not None else self.default_workers,
+            )
 
             @functools.wraps(fn)
             def wrapper(*args, **kwargs) -> Node:

--- a/tutorial.py
+++ b/tutorial.py
@@ -50,7 +50,7 @@ advanced = Flow(
     cache=ChainCache([MemoryLRU(), DiskJoblib(".cache")]),
     config=Config(yaml.safe_load(yaml_text)),
     executor="thread",
-    workers=2,
+    default_workers=2,
 )
 
 


### PR DESCRIPTION
## Summary
- allow configuring `default_workers` in `Flow`
- nodes without explicit workers now inherit `Flow.default_workers`
- update docs, tutorial, and benchmark examples to use `default_workers`
- adapt tests to new parameter name

## Testing
- `ruff format src/node/node.py tests/test_flow.py bench_flow.py tutorial.py`
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685565167854832b91726862629d33fb