### PR TITLE
Add force terminal parameter for RichReporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ add:
 python tutorial.py
 ```
 
+## 解决多进程下 RichReporter 跳动
+
+在进程池执行时，多个进程同时向终端写入会导致 `RichReporter` 的进度条跳动。
+可以在主进程独占终端，并强制 Rich 将控制台视为真实终端：
+
+```python
+from rich.console import Console
+from node.reporters import RichReporter
+
+flow = Flow(executor="process")
+reporter = RichReporter(console=Console(force_terminal=True))
+flow.run(root, reporter=reporter)
+```
+
+确保工作进程不要向标准输出打印内容，以避免刷新冲突。
+
 
 
 

--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -40,6 +40,7 @@ class RichReporter:
         show_script_line: bool = True,
         *,
         console: Console | None = None,
+        force_terminal: bool = False,
     ):
         """Create reporter.
 
@@ -49,11 +50,19 @@ class RichReporter:
             UI refresh rate.
         show_script_line:
             Display canonical script line instead of ``_render_call``.
+        force_terminal:
+            Force Rich to treat the console as a real terminal.
         """
 
         self.refresh_per_second = refresh_per_second
         self.show_script_line = show_script_line
-        self.console = console or _console
+        if console is None:
+            if force_terminal:
+                self.console = Console(force_terminal=True)
+            else:
+                self.console = _console
+        else:
+            self.console = console
 
     def attach(self, engine: "Engine", root: Node):
         """Return a context manager bound to ``engine`` and ``root``."""


### PR DESCRIPTION
## Summary
- support `force_terminal` in `RichReporter` to stabilize multiprocess output
- document using `Console(force_terminal=True)` in the README

## Testing
- `pip install -e .`
- `ruff format --quiet .`
- `ruff check --quiet .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566de27b28832bacfafc0c0680cd86