### PR TITLE
Fix nested RichReporter

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 # coverage: ignore-file
 
 from typing import Dict, TYPE_CHECKING
+from contextlib import nullcontext
 import time
 import sys
 import threading
@@ -65,7 +66,13 @@ class RichReporter:
             self.console = console
 
     def attach(self, engine: "Engine", root: Node):
-        """Return a context manager bound to ``engine`` and ``root``."""
+        """Return a context manager bound to ``engine`` and ``root``.
+
+        If the console already has an active live display, a no-op context
+        manager is returned to avoid nested :class:`rich.live.Live` errors.
+        """
+        if getattr(self.console, "_live", None) is not None:
+            return nullcontext()
         return _RichReporterCtx(self, engine, root)
 
 


### PR DESCRIPTION
## Summary
- avoid `LiveError` when `RichReporter` is nested by checking for an existing live display

## Testing
- `ruff format --check .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68567a9c28e4832b96d9b6b6cc5f357e