### PR TITLE
Add pause context to RichReporter

### DIFF
--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -10,6 +10,7 @@ from queue import SimpleQueue, Empty
 
 from rich.live import Live  # type: ignore[import]
 from rich.console import Group, Console  # type: ignore[import]
+from rich.columns import Columns  # type: ignore[import]
 from rich.text import Text  # type: ignore[import]
 from rich.spinner import Spinner  # type: ignore[import]
 from rich.syntax import Syntax  # type: ignore[import]
@@ -307,10 +308,15 @@ class _RichReporterCtx:
         out = [self._header(final)]
         now = time.perf_counter()
         icon = str(self.spinner.render(now))
+        progs = list(self._progs)
         for label, ts in list(self.running.values()):
             dur = self._format_dur(now - ts)
-            out.append(Text.assemble(icon, " ", label, (f" [{dur}]", "gray50")))
-        for prog in self._progs:
+            line: Text | Columns
+            line = Text.assemble(icon, " ", label, (f" [{dur}]", "gray50"))
+            if progs:
+                line = Columns([line, progs.pop(0).get_renderable()], expand=True)
+            out.append(line)
+        for prog in progs:
             out.append(prog.get_renderable())
         return Group(*out)
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -48,3 +48,16 @@ def test_start_uses_syntax():
     from rich.text import Text
 
     assert isinstance(label, Text)
+
+
+def test_pause_allows_nested_live():
+    ctx = _make_ctx()
+    ctx.__enter__()
+    try:
+        from rich.live import Live
+
+        with ctx.pause():
+            with Live("hi", console=ctx.cfg.console):
+                pass
+    finally:
+        ctx.__exit__(None, None, None)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -61,3 +61,15 @@ def test_pause_allows_nested_live():
                 pass
     finally:
         ctx.__exit__(None, None, None)
+
+
+def test_track_yields_all_values():
+    ctx = _make_ctx()
+    ctx.__enter__()
+    try:
+        out = []
+        for x in ctx.track(range(3), total=3):
+            out.append(x)
+        assert out == [0, 1, 2]
+    finally:
+        ctx.__exit__(None, None, None)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -73,3 +73,16 @@ def test_track_yields_all_values():
         assert out == [0, 1, 2]
     finally:
         ctx.__exit__(None, None, None)
+
+
+def test_track_renders_description():
+    ctx = _make_ctx()
+    ctx.__enter__()
+    try:
+        gen = ctx.track(range(1), description="my_node", total=1)
+        next(gen)
+        with ctx.cfg.console.capture() as cap:
+            ctx.cfg.console.print(ctx._render())
+        assert "my_node" in cap.get()
+    finally:
+        ctx.__exit__(None, None, None)


### PR DESCRIPTION
## Summary
- allow RichReporter to pause its Live display
- add _PauseCtx helper and tests

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856d62a56f4832b9c536c0f222413a1