### PR TITLE
Override loguru logger instance

### DIFF
--- a/src/node/logger.py
+++ b/src/node/logger.py
@@ -1,6 +1,7 @@
 """Pre-configured Loguru logger with Rich output."""
 
 from loguru import logger
+import sys
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.traceback import install
@@ -25,6 +26,9 @@ logger.add(
     level="DEBUG",
     format="{message}",
 )
+
+# ensure future `from loguru import logger` returns this configured instance
+sys.modules["loguru"].logger = logger  # type: ignore[attr-defined]
 
 __all__ = ["logger", "console"]
 


### PR DESCRIPTION
## Summary
- ensure any `from loguru import logger` returns the Rich-configured instance

## Testing
- `ruff format src/node/logger.py`
- `ruff check src/node/logger.py`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ccacd5b04832bbc64a83de1e211c2