### PR TITLE
Fix logger spacing in Jupyter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Node 是一个轻量级、零依赖的 DAG 流程库，适合在脚本或小型�
 - **回调钩子**：`on_node_end` 与 `on_flow_end` 可用来收集统计信息。
 - **结果聚合**：`gather` 工具可将多个节点合并为一个列表返回，方便并行处理。
 - **日志模块**：`from node import logger` 即可获得预配置的 `loguru` 记录器。
+  在 Jupyter Notebook 中会自动切换为 `force_terminal` 模式，避免日志
+  输出间出现大间隔。
 
 ## 安装
 
@@ -134,11 +136,12 @@ python tutorial.py
 可以在主进程独占终端，并强制 Rich 将控制台视为真实终端：
 
 ```python
-from rich.console import Console
+from node import logger
 from node.reporters import RichReporter
 
 flow = Flow(executor="process")
-reporter = RichReporter(console=Console(force_terminal=True))
+logger.console._force_terminal = True  # reuse the global console
+reporter = RichReporter(force_terminal=True)
 flow.run(root, reporter=reporter)
 ```
 

--- a/src/node/logger.py
+++ b/src/node/logger.py
@@ -9,7 +9,7 @@ from rich.traceback import install
 # beautify tracebacks with Rich
 install()
 
-console = Console()
+console = Console(force_terminal="ipykernel" in sys.modules)
 
 # remove default handler
 logger.remove()

--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -83,13 +83,12 @@ class RichReporter:
 
         self.refresh_per_second = refresh_per_second
         self.show_script_line = show_script_line
-        if console is None:
-            if force_terminal:
-                self.console = Console(force_terminal=True)
-            else:
-                self.console = _console
-        else:
-            self.console = console
+        self.console = console or _console
+        if force_terminal:
+            # Rich stores the flag on a private attribute; mutate in place to
+            # avoid creating additional consoles and keep output unified.
+            if hasattr(self.console, "_force_terminal"):
+                self.console._force_terminal = True
 
     def attach(self, engine: "Engine", root: Node):
         """Return a context manager bound to ``engine`` and ``root``.
@@ -395,4 +394,6 @@ def track(
     else:
         from rich.progress import track as _track
 
-        yield from _track(sequence, description=description, total=total)
+        yield from _track(
+            sequence, description=description, total=total, console=_console
+        )

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,6 +1,6 @@
-from rich.console import Console
 from node.node import Flow
 from node.reporters import RichReporter, track
+from node.logger import console
 
 
 def test_track_inside_node():
@@ -14,6 +14,6 @@ def test_track_inside_node():
         return total
 
     root = loop(5)
-    reporter = RichReporter(console=Console(force_terminal=True))
+    reporter = RichReporter(console=console, force_terminal=True)
     result = flow.run(root, reporter=reporter)
     assert result == 10

--- a/tests/test_track_process.py
+++ b/tests/test_track_process.py
@@ -1,6 +1,6 @@
-from rich.console import Console
 from node.node import Flow
 from node.reporters import RichReporter, track
+from node.logger import console
 
 
 def test_track_inside_node_process():
@@ -14,6 +14,6 @@ def test_track_inside_node_process():
         return total
 
     root = loop(5)
-    reporter = RichReporter(console=Console(force_terminal=True))
+    reporter = RichReporter(console=console, force_terminal=True)
     result = flow.run(root, reporter=reporter)
     assert result == 10


### PR DESCRIPTION
## Summary
- tweak `logger` to force terminal mode when running inside Jupyter
- update README explaining the notebook behaviour
- ensure all output uses one console and update tests accordingly

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ccfae0118832b8ba8a107cb2a5702