### PR TITLE
Add workers argument to gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Node 是一个轻量级、零依赖的 DAG 流程库，适合在脚本或小型�
 - **脚本表示**：任意节点的 `repr()` 都会生成等效的 Python 调用脚本。
 - **配置系统**：通过 `Config` 对象集中管理任务默认参数，支持从 YAML 加载。
 - **回调钩子**：`on_node_end` 与 `on_flow_end` 可用来收集统计信息。
-- **结果聚合**：`gather` 工具可将多个节点合并为一个列表返回，方便并行处理。
+- **结果聚合**：`gather` 工具可将多个节点合并为一个列表返回，支持 `workers`
+  参数控制聚合节点的并发度。
 - **日志模块**：`from node import logger` 即可获得预配置的 `loguru` 记录器。
   在 Jupyter Notebook 中会自动切换为 `force_terminal` 模式，避免日志
   输出间出现大间隔。
@@ -50,8 +51,8 @@ def train(x, y, large_df, model):
 result = flow.run(square(add(2, 3)))
 print(result)  # 25
 
-# gather 多个独立节点（也可传入列表）
-result = flow.run(gather([add(1, 2), add(3, 4)]))
+# gather 多个独立节点（也可传入列表），workers 控制聚合阶段的线程数
+result = flow.run(gather([add(1, 2), add(3, 4)], workers=2))
 print(result)  # [3, 7]
 ```
 

--- a/src/node/node.py
+++ b/src/node/node.py
@@ -774,13 +774,14 @@ class Flow:
             _render_cache.clear()
 
 
-def gather(*nodes: Node | Iterable[Node]) -> Node:
+def gather(*nodes: Node | Iterable[Node], workers: int | None = None) -> Node:
     """Aggregate multiple nodes into a single list result.
 
     ``nodes`` may be passed either as positional arguments or as a single
     iterable.  All input nodes must belong to the same :class:`Flow`. The
     returned node produces a list of each input node's value in the provided
-    order.
+    order.  ``workers`` controls the concurrent executions of the gather
+    node itself.
     """
 
     if len(nodes) == 1 and not isinstance(nodes[0], Node):
@@ -795,7 +796,7 @@ def gather(*nodes: Node | Iterable[Node]) -> Node:
     if any(n.flow is not flow for n in nodes_list):
         raise ValueError("nodes belong to different Flow instances")
 
-    @flow.node()
+    @flow.node(workers=workers)
     def _gather(*items):
         return list(items)
 

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -34,3 +34,14 @@ def test_gather_flow_mismatch(flow_factory):
 
     with pytest.raises(ValueError):
         gather(a(1), b(2))
+
+
+def test_gather_custom_workers(flow_factory):
+    flow = flow_factory()
+
+    @flow.node()
+    def inc(x):
+        return x + 1
+
+    node = gather(inc(1), workers=3)
+    assert node.fn._node_workers == 3


### PR DESCRIPTION
## Summary
- allow `gather` to set worker count for its node
- document new `gather` capability
- test workers option on `gather`

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cebdcfe28832b8ff4340d105dac88