### PR TITLE
Fix notebook logging spacing

### DIFF
--- a/src/node/logger.py
+++ b/src/node/logger.py
@@ -1,4 +1,8 @@
-"""Pre-configured Loguru logger with Rich output."""
+"""Pre-configured Loguru logger with Rich output.
+
+When running in Jupyter, ``RichHandler`` will send raw text to stdout
+instead of emitting independent HTML blocks.
+"""
 
 from loguru import logger
 import sys
@@ -9,7 +13,8 @@ from rich.traceback import install
 # beautify tracebacks with Rich
 install()
 
-console = Console()
+IN_JUPYTER = "ipykernel" in sys.modules
+console = Console(force_terminal=IN_JUPYTER)
 
 # remove default handler
 logger.remove()


### PR DESCRIPTION
## Summary
- detect Jupyter environment in the logger
- force `Console` to treat notebook output as terminal

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d2b8e9d4c832bb4a66c34221dfffa