### PR TITLE
Optimize single worker run path

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -551,7 +551,15 @@ class Engine:
         t0 = time.perf_counter()
         order = root.order
 
-        if self.workers <= 1:
+        max_node_workers = 1
+        for node in order:
+            workers = getattr(node.fn, "_node_workers", 1)
+            if workers == -1:
+                workers = os.cpu_count() or 1
+            if workers > max_node_workers:
+                max_node_workers = workers
+
+        if min(self.workers, max_node_workers) <= 1:
             for node in order:
                 self._eval_node(node)
             wall = time.perf_counter() - t0

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -369,6 +369,36 @@ def test_single_worker_no_pool(flow_factory, monkeypatch):
     assert not called
 
 
+def test_node_workers_no_pool(flow_factory, monkeypatch):
+    import node.node as node_module
+    import time
+
+    called = False
+
+    def fail_pool(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("ThreadPoolExecutor should not be used")
+
+    monkeypatch.setattr(node_module, "ThreadPoolExecutor", fail_pool)
+
+    flow = flow_factory(executor="thread", default_workers=2)
+
+    @flow.node(workers=1)
+    def slow(v):
+        import time
+
+        time.sleep(0.05)
+        return v
+
+    root = slow(1)
+    t0 = time.perf_counter()
+    assert flow.run(root) == 1
+    elapsed = time.perf_counter() - t0
+    assert elapsed >= 0.05
+    assert not called
+
+
 def test_cycle_detection():
     """Creating a node that depends on itself should raise."""
 


### PR DESCRIPTION
## Summary
- short-circuit `Engine.run` when only one worker is specified
- add a regression test ensuring thread pools aren't created for a single worker

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5fa13fd4832b8d852b2516761a0e