### PR TITLE
Implement failure propagation and display

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "cachetools>=6.0.0",
     "cloudpickle>=3.1.1",
+    "coverage>=7.9.2",
     "filelock>=3.18.0",
     "joblib>=1.5.1",
     "loguru>=0.7.3",

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -12,5 +12,5 @@ def test_continue_on_error(flow_factory, capsys):
 
     result = flow.run(inc(fail()))
     captured = capsys.readouterr().out
-    assert result == 1
+    assert result is None
     assert "failed" in captured

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -431,11 +431,11 @@ def test_dict_canonicalization(flow_factory):
 def test_callbacks_invoked(flow_factory):
     events = []
 
-    def on_node_end(node, dur, cached):
-        events.append(("node", cached))
+    def on_node_end(node, dur, cached, failed):
+        events.append(("node", cached, failed))
 
-    def on_flow_end(root, wall, count):
-        events.append(("flow", count))
+    def on_flow_end(root, wall, count, fails):
+        events.append(("flow", count, fails))
 
     flow = flow_factory()
     flow.engine.on_node_end = on_node_end
@@ -447,11 +447,11 @@ def test_callbacks_invoked(flow_factory):
 
     node = add(1, 2)
     assert flow.run(node) == 3
-    assert events == [("node", False), ("flow", 1)]
+    assert events == [("node", False, False), ("flow", 1, 0)]
 
     events.clear()
     assert flow.run(node) == 3
-    assert events == [("node", True), ("flow", 0)]
+    assert events == [("node", True, False), ("flow", 0, 0)]
 
 
 def test_cache_scripts(flow_factory, tmp_path):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -2,7 +2,7 @@ from node.node import Flow
 from node.reporters import RichReporter
 
 
-def _make_ctx(hits=0, execs=0):
+def _make_ctx(hits=0, execs=0, fails=0):
     flow = Flow()
 
     @flow.node()
@@ -14,6 +14,7 @@ def _make_ctx(hits=0, execs=0):
     ctx.total = 1
     ctx.hits = hits
     ctx.execs = execs
+    ctx.fails = fails
     return ctx
 
 
@@ -36,6 +37,12 @@ def test_format_duration():
     assert ctx._format_dur(5) == "5.0s"
     assert ctx._format_dur(65) == "1m 5s"
     assert ctx._format_dur(3661) == "1h 1m 1s"
+
+
+def test_header_shows_fail():
+    ctx = _make_ctx(execs=1, fails=1)
+    header = ctx._header(final=False).plain
+    assert "❌ Fail" in header
 
 
 def test_start_uses_syntax():

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
     { name = "cloudpickle" },
+    { name = "coverage" },
     { name = "filelock" },
     { name = "joblib" },
     { name = "loguru" },
@@ -206,6 +207,7 @@ dependencies = [
 requires-dist = [
     { name = "cachetools", specifier = ">=6.0.0" },
     { name = "cloudpickle", specifier = ">=3.1.1" },
+    { name = "coverage", specifier = ">=7.9.2" },
     { name = "filelock", specifier = ">=3.18.0" },
     { name = "joblib", specifier = ">=1.5.1" },
     { name = "loguru", specifier = ">=0.7.3" },


### PR DESCRIPTION
## Summary
- propagate failures to downstream nodes
- show failing node count in RichReporter progress header
- adjust callbacks to provide failure flag
- update tests for new behavior
- record `coverage` dependency

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3cebb050832ba5ac5c4ca15d4071