### PR TITLE
Integrate OmegaConf for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,23 +106,21 @@ flow = Flow(
 使用 `Config` 管理任务默认参数：
 
 ```python
-import yaml
 from node.node import Flow, Config
 
-with open("defaults.yml") as f:
-    defaults = yaml.safe_load(f)
-
-flow = Flow(config=Config(defaults))
+flow = Flow(config=Config("defaults.yml"))
 ```
 
 示例 `defaults.yml`：
 
 ```yaml
+base:
+  val: 5
 add:
-  y: 5
+  y: ${base.val}
 ```
 
-测试目录中的 `tests/config.yaml` 亦可参考。
+测试目录中的 `tests/config.yaml` 亦可参考，该文件演示了配置引用。
 
 ## 教程脚本
 

--- a/README_CONFIG.md
+++ b/README_CONFIG.md
@@ -1,0 +1,32 @@
+# Configuration Guide
+
+This project uses **OmegaConf** to manage default arguments for tasks. You can
+load configuration from a YAML file or from a Python mapping. OmegaConf allows
+you to reference other keys using `${...}` syntax.
+
+## Load from YAML
+
+```python
+from node.node import Flow, Config
+
+flow = Flow(config=Config("config.yaml"))
+```
+
+Example `config.yaml`:
+
+```yaml
+common:
+  value: 10
+add:
+  y: ${common.value}
+```
+
+## Load from mapping
+
+```python
+conf = Config({"add": {"y": 5}})
+flow = Flow(config=conf)
+```
+
+All values returned by `Config.defaults()` are resolved, so references are
+expanded automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "loky>=3.5.5",
     "markdown-it-py>=3.0.0",
     "mdurl>=0.1.2",
+    "omegaconf>=2.3.0",
     "pytest>=8.4.0",
     "pytest-cov>=6.2.1",
     "pyyaml>=6.0.2",

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,2 +1,4 @@
+base:
+  val: 5
 add:
-  y: 5
+  y: ${base.val}

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -2,9 +2,8 @@ from pathlib import Path
 from contextlib import nullcontext
 import threading
 
-import yaml  # type: ignore[import]
-import pytest
 from node.node import Node, Config, ChainCache, MemoryLRU, DiskJoblib
+import pytest
 
 
 def test_flow_example(flow_factory):
@@ -140,10 +139,7 @@ def test_positional_args_ignore_config(flow_factory):
 
 def test_config_from_yaml(flow_factory):
     cfg_path = Path(__file__).with_name("config.yaml")
-    with open(cfg_path) as f:
-        defaults = yaml.safe_load(f)
-
-    flow = flow_factory(config=Config(defaults))
+    flow = flow_factory(config=Config(cfg_path))
 
     @flow.node()
     def add(x, y=1):

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,12 @@ revision = 2
 requires-python = ">=3.10"
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
 name = "cachetools"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -196,6 +202,7 @@ dependencies = [
     { name = "loky" },
     { name = "markdown-it-py" },
     { name = "mdurl" },
+    { name = "omegaconf" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pyyaml" },
@@ -212,10 +219,24 @@ requires-dist = [
     { name = "loky", specifier = ">=3.5.5" },
     { name = "markdown-it-py", specifier = ">=3.0.0" },
     { name = "mdurl", specifier = ">=0.1.2" },
+    { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich", specifier = ">=14.0.0" },
+]
+
+[[package]]
+name = "omegaconf"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/94/1843518e420fa3ed6919835845df698c7e27e183cb997394e4a670973a65/omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b", size = 79500, upload-time = "2022-12-08T20:59:19.686Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- use OmegaConf in `Config` and allow loading from YAML path
- document new configuration options
- update sample YAML with reference
- update tests to exercise OmegaConf loading
- add OmegaConf dependency

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b3e47b2a4832bac30ef0c4840d2a3