### PR TITLE
Add dependency injection via config

### DIFF
--- a/tests/test_config_dependency.py
+++ b/tests/test_config_dependency.py
@@ -1,0 +1,31 @@
+from node.node import Flow, Config
+
+flow = Flow()
+
+
+@flow.node()
+def taska(param1: int, param2: int) -> int:
+    return param1 + param2
+
+
+@flow.node()
+def taskb(depend: int, param1: int) -> int:
+    return depend + param1
+
+
+def test_config_dependency(tmp_path):
+    cfg = {
+        "taska": {
+            "_target_": "test_config_dependency.taska",
+            "param1": 2,
+            "param2": 3,
+        },
+        "taskb": {
+            "depend": "${taska}",
+            "param1": 5,
+        },
+    }
+    config = Config(cfg)
+    flow.config = config
+    node = taskb()
+    assert node.get() == 10


### PR DESCRIPTION
## Summary
- allow `Config` to instantiate nodes referenced in YAML
- support nested references when filling defaults
- pass `flow` into `Config.defaults` to enable node construction
- test config node dependency injection

## Testing
- `ruff format --silent .`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4af8b28c832bb61f52aa4de27cf4