### PR TITLE
Fix Config interpolation for scalars

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -793,8 +793,10 @@ class Config:
     def _resolve_value(self, val: Any, flow: "Flow") -> Any:
         if isinstance(val, str) and val.startswith("${") and val.endswith("}"):
             key = val[2:-1]
-            if key in self._conf and "_target_" in self._conf[key]:
-                return self._build_node(key, flow)
+            if key in self._conf:
+                cfg_val = self._conf[key]
+                if OmegaConf.is_dict(cfg_val) and "_target_" in cfg_val:
+                    return self._build_node(key, flow)
             return OmegaConf.select(self._conf, key)
         return val
 

--- a/tests/test_config_scalar_interpolation.py
+++ b/tests/test_config_scalar_interpolation.py
@@ -1,0 +1,20 @@
+from node.node import Config
+
+
+def test_scalar_interpolation(flow_factory):
+    flow = flow_factory()
+
+    @flow.node()
+    def show_year(year: int) -> int:
+        return year
+
+    cfg = {
+        "year": 2023,
+        "show_year": {
+            "_target_": f"{__name__}.show_year",
+            "year": "${year}",
+        },
+    }
+    flow.config = Config(cfg)
+    node = show_year()
+    assert node.get() == 2023


### PR DESCRIPTION
## Summary
- avoid membership checks on scalars in `Config._resolve_value`
- add regression test for scalar interpolation
- use `OmegaConf.is_dict` for config type detection

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b5496bd78832b80c79c293784b0a9