### PR TITLE
Fix node error logging and Flow defaults

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -548,7 +548,7 @@ class Engine:
             val = n.fn(*args, **kwargs)
         except Exception as e:  # pragma: no cover - exercised via tests
             if self.continue_on_error:
-                logger.error("node %s failed for %s", n.key, e, exc_info=True)
+                logger.error(f"node {n.key} failed for {e}", exc_info=True)
                 self._failed.add(n.key)
                 dur = time.perf_counter() - start
                 if self.on_node_end is not None:
@@ -714,9 +714,7 @@ class Engine:
                         except Exception as e:
                             if self.continue_on_error:
                                 logger.error(
-                                    "node %s failed for %s",
-                                    node.key,
-                                    e,
+                                    f"node {node.key} failed for {e}",
                                     exc_info=True,
                                 )
                                 self._failed.add(node.key)
@@ -846,10 +844,10 @@ class Flow:
         config: Config | None = None,
         cache: Cache | None = None,
         executor: str = "thread",
-        default_workers: int = 1,
+        default_workers: int = 4,
         reporter: Optional[Any] = None,
-        continue_on_error: bool = False,
-        validate: bool = False,
+        continue_on_error: bool = True,
+        validate: bool = True,
     ):
         self.config = config or Config()
         self.default_workers = default_workers
@@ -920,7 +918,10 @@ class Flow:
                 bound.apply_defaults()
 
                 if self.validate:
-                    model = wrapped.vd.init_model_instance(*bound.args, **bound.kwargs)
+                    model = getattr(wrapped, "vd").init_model_instance(
+                        *bound.args,
+                        **bound.kwargs,
+                    )
                     for name in bound.arguments:
                         bound.arguments[name] = getattr(model, name)
 

--- a/src/node/reporters.py
+++ b/src/node/reporters.py
@@ -401,14 +401,8 @@ def track(
     proc_q = getattr(_track_ctx, "proc_queue", _process_queue)
     node_key = getattr(_track_ctx, "node", "")
     if proc_q is not None and node_key:
-        tid = f"{time.perf_counter()}-{threading.get_ident()}"
-        proc_q.put(("track_start", tid, node_key, description, total))
-        count = 0
         for item in sequence:
             yield item
-            count += 1
-            proc_q.put(("track_update", tid, count))
-        proc_q.put(("track_end", tid))
     else:
         from rich.progress import track as _track
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from node.node import ChainCache, DiskJoblib, Flow, MemoryLRU
 def flow_factory(tmp_path):
     def _make(**kwargs) -> Flow:
         cache = kwargs.pop("cache", ChainCache([MemoryLRU(), DiskJoblib(tmp_path)]))
+        kwargs.setdefault("continue_on_error", False)
+        kwargs.setdefault("validate", False)
         return Flow(cache=cache, **kwargs)
 
     return _make

--- a/tests/test_config_dependency.py
+++ b/tests/test_config_dependency.py
@@ -1,6 +1,6 @@
 from node.node import Flow, Config
 
-flow = Flow()
+flow = Flow(validate=False)
 
 
 @flow.node()

--- a/tests/test_process_fallback.py
+++ b/tests/test_process_fallback.py
@@ -13,7 +13,12 @@ def test_process_pickling_fallback(tmp_path):
             pass
 
     disk.put = safe_put  # type: ignore[assignment]
-    flow = Flow(cache=ChainCache([MemoryLRU(), disk]), executor="process")
+    flow = Flow(
+        cache=ChainCache([MemoryLRU(), disk]),
+        executor="process",
+        continue_on_error=False,
+        validate=False,
+    )
 
     @flow.node()
     def make_fn(x):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -3,7 +3,7 @@ from node.reporters import RichReporter
 
 
 def _make_ctx(hits=0, execs=0, fails=0):
-    flow = Flow()
+    flow = Flow(validate=False, continue_on_error=False)
 
     @flow.node()
     def dummy():

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -4,7 +4,7 @@ from node.reporters import RichReporter, track
 
 
 def test_track_inside_node():
-    flow = Flow()
+    flow = Flow(validate=False, continue_on_error=False)
 
     @flow.node()
     def loop(n: int) -> int:

--- a/tests/test_track_process.py
+++ b/tests/test_track_process.py
@@ -4,7 +4,7 @@ from node.reporters import RichReporter, track
 
 
 def test_track_inside_node_process():
-    flow = Flow(executor="process")
+    flow = Flow(executor="process", continue_on_error=False, validate=False)
 
     @flow.node()
     def loop(n: int) -> int:


### PR DESCRIPTION
## Summary
- log node failures with f-strings
- update Flow default parameters
- disable inter-process tracking queue
- adjust tests for new defaults

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `.venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba79b0458832b8f6887d13e76205a