### PR TITLE
Add cache option to gather helper

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -984,7 +984,11 @@ class Flow:
             _render_cache.clear()
 
 
-def gather(*nodes: Node | Iterable[Node], workers: int | None = None) -> Node:
+def gather(
+    *nodes: Node | Iterable[Node],
+    workers: int | None = None,
+    cache: bool = True,
+) -> Node:
     """Aggregate multiple nodes into a single list result.
 
     ``nodes`` may be passed either as positional arguments or as a single
@@ -1006,7 +1010,7 @@ def gather(*nodes: Node | Iterable[Node], workers: int | None = None) -> Node:
     if any(n.flow is not flow for n in nodes_list):
         raise ValueError("nodes belong to different Flow instances")
 
-    @flow.node(workers=workers)
+    @flow.node(workers=workers, cache=cache)
     def _gather(*items):
         return list(items)
 

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -45,3 +45,14 @@ def test_gather_custom_workers(flow_factory):
 
     node = gather(inc(1), workers=3)
     assert node.fn._node_workers == 3
+
+
+def test_gather_cache_toggle(flow_factory):
+    flow = flow_factory()
+
+    @flow.node()
+    def inc(x):
+        return x + 1
+
+    node = gather(inc(1), cache=False)
+    assert node.cache is False


### PR DESCRIPTION
## Summary
- expose `cache` setting on `gather`
- test the `cache` parameter

## Testing
- `ruff check`
- `ruff format --check`
- `mypy src/node/node.py` *(fails: Item "function" of "Any | Callable[..., Any]" has no attribute "vd")*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ba485dab8832bbb2ea32661c0fad6