### PR TITLE
Implement config reset shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ add:
   y: ${base.val}
 ```
 
+配置加载后，可直接访问内部配置并在运行时修改，再用 `flow.reset_config()` 恢复最初的参数：
+
+```python
+cfg = flow.config._conf
+cfg.add.y = 3
+flow.reset_config()
+```
+
 测试目录中的 `tests/config.yaml` 亦可参考，该文件演示了配置引用。
 
 ## 教程脚本

--- a/src/node/node.py
+++ b/src/node/node.py
@@ -849,7 +849,8 @@ class Flow:
         continue_on_error: bool = True,
         validate: bool = True,
     ):
-        self.config = config or Config()
+        self.config = config if isinstance(config, Config) else Config(config)
+        self._initial_config = Config(OmegaConf.create(self.config._conf))
         self.default_workers = default_workers
         self.engine = Engine(
             cache=cache,
@@ -868,6 +869,10 @@ class Flow:
                 self.reporter = _RR()
         else:
             self.reporter = reporter
+
+    def reset_config(self) -> None:
+        """Restore the configuration used at initialization."""
+        self.config = Config(OmegaConf.create(self._initial_config._conf))
 
     def node(
         self,


### PR DESCRIPTION
## Summary
- simplify flow configuration handling
- allow direct modification of the underlying OmegaConf object
- keep a copy of the initial config for resets

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687bafcd2ce4832ba49ce485ae67b8e3