### PR TITLE
Fix Flow.reset_config to preserve config references

### DIFF
--- a/src/node/node.py
+++ b/src/node/node.py
@@ -867,6 +867,16 @@ class Config:
             result[k] = self._resolve_value(v, flow)
         return result
 
+    def copy_from(self, other: "Config") -> None:
+        """Copy ``other`` into this config without changing object identity."""
+        self._cache_nodes = other._cache_nodes
+        self._nodes.clear()
+        for key in list(self._conf.keys()):
+            del self._conf[key]
+        data = OmegaConf.to_container(other._conf, resolve=False) or {}
+        for key, value in data.items():
+            self._conf[key] = value
+
 
 class Flow:
     def __init__(
@@ -906,10 +916,7 @@ class Flow:
 
     def reset_config(self) -> None:
         """Restore the configuration used at initialization."""
-        self.config = Config(
-            OmegaConf.create(self._initial_config._conf),
-            cache_nodes=self._initial_config._cache_nodes,
-        )
+        self.config.copy_from(self._initial_config)
 
     def node(
         self,


### PR DESCRIPTION
## Summary
- add a Config.copy_from helper to overwrite existing DictConfig contents without changing object identity
- update Flow.reset_config to reuse copy_from so external references remain valid after resets

## Testing
- uv run ruff check .
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68db7802370c832b980c3b2208aa092c