### PR TITLE
feat: support node configuration presets

### DIFF
--- a/README_CONFIG.md
+++ b/README_CONFIG.md
@@ -30,3 +30,33 @@ flow = Flow(config=conf)
 
 All values returned by `Config.defaults()` are resolved, so references are
 expanded automatically.
+
+## Use presets from configuration
+
+Nodes can opt into **presets** that bundle together frequently used argument
+combinations. Define presets under the `_presets` key for a task in your YAML
+configuration and activate them when calling the node:
+
+```yaml
+train:
+  learning_rate: 0.01
+  _presets:
+    fast:
+      epochs: 5
+      batch_size: 32
+    accurate:
+      epochs: 50
+      batch_size: 16
+```
+
+```python
+@flow.node()
+def train(*, learning_rate: float, epochs: int, batch_size: int) -> None:
+    ...
+
+train(presets="fast")  # uses the `fast` overrides from the config
+```
+
+Multiple presets can be combined using a sequence (e.g. `presets=("fast",
+"accurate")`). Later presets override earlier ones, and any explicit keyword
+arguments passed to the node always win over preset values.

--- a/tests/test_config_presets.py
+++ b/tests/test_config_presets.py
@@ -1,0 +1,46 @@
+import pytest
+
+from node.node import Config, Flow
+
+
+def test_presets_apply_overrides():
+    flow = Flow(validate=False)
+
+    @flow.node()
+    def add(x: int, y: int, z: int = 0) -> int:
+        return x + y + z
+
+    config = Config(
+        {
+            "baseline": {"value": 5},
+            "add": {
+                "y": 1,
+                "_presets": {
+                    "fast": {"y": 2, "z": 3},
+                    "ref": {"z": "${baseline.value}"},
+                },
+            },
+        }
+    )
+    flow.config = config
+
+    assert add(1).get() == 2
+    assert add(1, presets="fast").get() == 6
+    assert add(1, presets=["fast", "ref"]).get() == 8
+    assert add(1, presets=("ref",)).get() == 7
+
+
+def test_presets_missing_entry_raises():
+    flow = Flow(validate=False)
+
+    @flow.node()
+    def task(x: int) -> int:
+        return x
+
+    flow.config = Config({"task": {"_presets": {"foo": {"x": 1}}}})
+
+    node = task(presets="foo")
+    assert node.get() == 1
+
+    with pytest.raises(KeyError, match="Preset 'bar' is not defined"):
+        task(presets="bar")


### PR DESCRIPTION
## Summary
- document how to declare `_presets` in configuration files and request them from nodes
- allow Flow nodes to accept a `presets` keyword that overlays config values when binding defaults
- cover preset behaviour and error handling with dedicated tests

## Testing
- `ruff format .`
- `ruff check .`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68df293bfcc0832bb6eb46d91810f733