### PR TITLE
refactor(runtime): lazy validate call setup

### DIFF
--- a/tests/test_runtime_reset.py
+++ b/tests/test_runtime_reset.py
@@ -1,0 +1,33 @@
+"""Tests for runtime reset behavior with pre-defined nodes."""
+
+import node
+from node import Config
+
+
+def test_define_uses_current_runtime_after_reset():
+    """Ensure nodes defined before reset pick up new runtime defaults."""
+    node.reset()
+    node.configure(
+        config=Config(
+            {
+                "global": 1,
+                "my_node": {"value": "${global}"},
+            }
+        )
+    )
+
+    @node.define()
+    def my_node(value: int) -> int:
+        return value
+
+    node.reset()
+    node.configure(
+        config=Config(
+            {
+                "global": 5,
+                "my_node": {"value": "${global}"},
+            }
+        )
+    )
+
+    assert my_node().get() == 5


### PR DESCRIPTION
### Motivation
- Avoid duplicate construction of validation wrappers and ensure nodes respect the active runtime's validation, defaults, and registry at invocation time.

### Description
- Remove eager validated wrapper construction at definition time and instead lazily construct and cache it via `get_validated_fn()`.
- Select between the validated function and the raw function at call time using `get_runtime().validate` and set `_node_workers` from the effective runtime or per-factory override.
- Use `current_runtime.config.defaults(...)` and `current_runtime._registry` when binding and caching `Node` instances so nodes defined before a `Runtime` reset pick up new defaults.
- Add `tests/test_runtime_reset.py` to verify runtime reset behavior for pre-defined nodes.

### Testing
- Added unit test `tests/test_runtime_reset.py` that asserts a node defined before `node.reset()` picks up new defaults after reconfiguration.
- No automated test suite was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967162c27dc8326aa9e709163a7fa14)